### PR TITLE
 fix-no-metadata-bug

### DIFF
--- a/libs/eventstore-interconnect/src/formatter/legacy-event-formatter/legacy-event-formatter.service.spec.ts
+++ b/libs/eventstore-interconnect/src/formatter/legacy-event-formatter/legacy-event-formatter.service.spec.ts
@@ -49,4 +49,27 @@ describe('LegacyEventFormatterService', () => {
       },
     });
   });
+
+  it('should handle an event with no metadata', () => {
+    const data = {};
+
+    const metadata: FormattedMetadata = {
+      eventId: '123',
+      eventStreamId: 'toto',
+      eventType: 'tutu',
+    };
+
+    const formatedEvent: FormattedEvent = service.format({
+      event: {
+        ...metadata,
+        id: 'toto',
+        data: Buffer.from(JSON.stringify(data), 'utf-8'),
+        metadata: Buffer.from('', 'utf-8'),
+      },
+    });
+    expect(formatedEvent).toEqual({
+      data,
+      metadata,
+    });
+  });
 });

--- a/libs/eventstore-interconnect/src/formatter/legacy-event-formatter/legacy-event-formatter.service.ts
+++ b/libs/eventstore-interconnect/src/formatter/legacy-event-formatter/legacy-event-formatter.service.ts
@@ -6,7 +6,12 @@ import { FormattedEvent } from '../formatted-event';
 export class LegacyEventFormatterService implements Formatter {
   public format(readonlyEvent: any): FormattedEvent {
     const data = JSON.parse(readonlyEvent.event.data.toString());
-    const metadata = JSON.parse(readonlyEvent.event.metadata.toString());
+    let metadata: any;
+    try {
+      metadata = JSON.parse(readonlyEvent.event.metadata.toString());
+    } catch (e: any) {
+      metadata = {};
+    }
     return {
       data,
       metadata: {


### PR DESCRIPTION
Add a try catch around JSON.parse(metadata) to be protected against no-metadata