### PR TITLE
feat: update js target 2017 -> 2021 for bigint

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2017",
+    "target": "es2021",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
Updated the target js version because ES lib now uses BigInt